### PR TITLE
configure github action workflow

### DIFF
--- a/.github/workflows/build_and_copy.yml
+++ b/.github/workflows/build_and_copy.yml
@@ -1,0 +1,44 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - main 
+
+jobs:
+  build_and_copy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: setup java 
+        uses: actions/setup-java@v1
+        with:
+            java-version: 16
+
+      - name: generate files using gradle
+        uses: eskatos/gradle-command-action@v1
+        with:
+            arguments: asciidoctor
+
+      - name: copy generated documentation files to e2immu-site
+        env:
+          REPO: satyamkapoor/hugotestagain
+          REPO_PATH: charts-release
+          SOURCE: build/docs/asciidoc/
+          TARGET: target/static/docs
+          GIT_USERNAME: action
+          GIT_EMAIL: action@github.com
+        run: |
+            git clone https://.:${{ secrets.GTOKEN }}@github.com/${{ env.REPO }} target
+            if [ -d ${{ env.TARGET }} ]; then rm -rf ${{ env.TARGET }}/*; fi
+            cp -r ${{ env.SOURCE }}* ${{ env.TARGET }}/
+            cd target
+            git config --local user.email "${{ env.GIT_EMAIL }}"
+            git config --local user.name "${{ env.GIT_USERNAME }}"
+            git add .
+            git commit -m "Github actions automatic build for `date +"%Y-%m-%d %H:%M"`"
+            git push origin --set-upstream main
+            
+

--- a/.github/workflows/build_and_copy.yml
+++ b/.github/workflows/build_and_copy.yml
@@ -24,8 +24,7 @@ jobs:
 
       - name: copy generated documentation files to e2immu-site
         env:
-          REPO: satyamkapoor/hugotestagain
-          REPO_PATH: charts-release
+          REPO: e2immu/e2immu-site
           SOURCE: build/docs/asciidoc/
           TARGET: target/static/docs
           GIT_USERNAME: action
@@ -38,7 +37,7 @@ jobs:
             git config --local user.email "${{ env.GIT_EMAIL }}"
             git config --local user.name "${{ env.GIT_USERNAME }}"
             git add .
-            git commit -m "Github actions automatic build for `date +"%Y-%m-%d %H:%M"`"
+            git commit -m "Github actions automatic build - `date +"%Y-%m-%d %H:%M"`"
             git push origin --set-upstream main
             
 


### PR DESCRIPTION
Hi,

I've added at workflow file which build the docs and copies them to e2immu-site/static/docs. We'll have to adapt the path in e2immu-site to adjust with the /docs path which didn't exists before.

Also, the workflow expects a secret - GTOKEN. You can create a personal access token or use an already existing one which has push write permissions for e2immu-site repo and place them in Project_Settings -> Secrets -> New repository secret with name GTOKEN (see image below).

![image](https://user-images.githubusercontent.com/6293731/114936954-6a630500-9e3d-11eb-8204-f929c99aceb5.png)
